### PR TITLE
chore: release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/bobsrac/hdc302x-rs/releases/tag/v0.1.0) - 2024-08-21
+
+### Other
+- embedded-hal-async driver for HDC302x(-Q1) temp/RH sensor


### PR DESCRIPTION
## 🤖 New release
* `hdc302x-async`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0](https://github.com/bobsrac/hdc302x-rs/releases/tag/v0.1.0) - 2024-08-21

### Other
- embedded-hal-async driver for HDC302x(-Q1) temp/RH sensor
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).